### PR TITLE
Hidden blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,20 @@ export class DataItem {
 ```
 This will produce two code snippets: one containing the whole view-model class and the other containing the `onShouldRefreshOnPull` function.
 
+## Hiding Blocks
+You can mark parts of the original code to be hidden - not shown in the documentation:
+``` TS
+// >> ts-snippet-with-hidden-section
+export function div(a, b){
+    // >> (hide)
+    console.log("You should not see this!")
+    // << (hide)    
+    return a / b;
+}
+// << ts-snippet-with-hidden-section
+```
+The syntax is similar in `XML` and `CSS`.
+
 ## Defining file extension filters
 You can choose what kind of files will be processed during snippet injection by using the `--sourceext` and `--targetext` parameters. The default values of these properties are `.ts` and `.md` respectively.
 

--- a/tests/docsroot/test.md
+++ b/tests/docsroot/test.md
@@ -1,8 +1,19 @@
 # XML snippet
 <snippet id='xml-snippet'/>
 
+This one has some hidden parts:
+<snippet id='xml-snippet-with-hidden-section'/>
+
 # JS/TS snippet:
 <snippet id='ts-snippet'/>
 
+This one has some hidden parts:
+<snippet id='ts-snippet-with-hidden-section'/>
+
+
 # CSS snippet:
 <snippet id='css-snippet'/>
+<snippet id='cssSnippet'/>
+
+This one has some hidden parts:
+<snippet id='css-snippet-with-hidden-section'/>

--- a/tests/root/test-css.css
+++ b/tests/root/test-css.css
@@ -4,3 +4,12 @@
     text-align: center;
 }
 /* << css-snippet */
+
+/* >> css-snippet-with-hidden-section */
+.btn {
+    color: green;
+    /* >> (hide) */
+    visibility: hidden;
+    /* << (hide) */
+}
+/* << css-snippet-with-hidden-section */

--- a/tests/root/test-ts.ts
+++ b/tests/root/test-ts.ts
@@ -3,3 +3,12 @@ export function sum(a, b){
     return a + b;
 }
 // << ts-snippet
+
+// >> ts-snippet-with-hidden-section
+export function div(a, b){
+    // >> (hide)
+    console.log("You should not see this!")
+    // << (hide)    
+    return a / b;
+}
+// << ts-snippet-with-hidden-section

--- a/tests/root/test-xml.xml
+++ b/tests/root/test-xml.xml
@@ -1,7 +1,19 @@
 <navigation:ExamplePage xmlns:navigation="navigation/example-page" loaded="onPageLoaded" xmlns:lv="nativescript-telerik-ui/listview" xmlns="http://www.nativescript.org/tns.xsd">
-<!-- >> xml-snippet -->
     <StackLayout>
-        <Label fontSize="20" text="{{ itemName }}"/>
+    <!-- >> xml-snippet -->
+        <StackLayout>
+            <Label fontSize="20" text="{{ itemName }}"/>
+        </StackLayout>
+    <!-- << xml-snippet -->
+
+    <!-- >> xml-snippet-with-hidden-section -->
+        <StackLayout>
+            <!-- >> (hide) -->
+            <Label text="you should not see this"/>
+            <!-- << (hide) -->
+            <Label fontSize="20" text="{{ itemName }}"/>
+        </StackLayout>
+    <!-- << xml-snippet-with-hidden-section -->
+    
     </StackLayout>
-<!-- << xml-snippet -->
 </navigation:ExamplePage>


### PR DESCRIPTION
Support the following syntax for hiding parts of the original code when creating the snippets:

```
// >> ts-snippet-with-hidden-section
export function div(a, b){
    // >> (hide)
    console.log("You should not see this!")
    // << (hide)    
    return a / b;
}
// << ts-snippet-with-hidden-section
```
